### PR TITLE
refactor: update board freq & memory maps based on src/ip/rt_pkg.sv

### DIFF
--- a/examples/rt_ss_bsp/src/lib.rs
+++ b/examples/rt_ss_bsp/src/lib.rs
@@ -49,7 +49,7 @@ impl Peripherals {
 pub const CPU_FREQ: u32 = if cfg!(feature = "rtl-tb") {
     100_000_000
 } else {
-    40_000_000
+    30_000_000
 };
 // Experimentally found value for how to adjust for real-time
 const fn nop_mult() -> u32 {

--- a/examples/rt_ss_bsp/src/mmap/clic.rs
+++ b/examples/rt_ss_bsp/src/mmap/clic.rs
@@ -1,4 +1,4 @@
-pub const CLIC_BASE_ADDR: usize = 0x50000;
+pub const CLIC_BASE_ADDR: usize = 0x5_0000;
 
 /* Register width */
 pub const CLIC_PARAM_REG_WIDTH: usize = 8;

--- a/examples/rt_ss_bsp/src/mmap/mod.rs
+++ b/examples/rt_ss_bsp/src/mmap/mod.rs
@@ -8,11 +8,13 @@
 #![allow(clippy::identity_op)]
 
 mod clic;
+mod spi;
 mod timer;
 mod uart;
 mod spi;
 
 pub use clic::*;
+pub use spi::*;
 pub use timer::*;
 pub use uart::*;
 pub use spi::*;

--- a/examples/rt_ss_bsp/src/mmap/mod.rs
+++ b/examples/rt_ss_bsp/src/mmap/mod.rs
@@ -1,4 +1,6 @@
 //! Memory maps for rt-ss
+//!
+//! Based on <src/ip/rt_pkg.sv>.
 
 // Some addresses are given in functional style but use all-caps for consistency
 #![allow(non_snake_case)]
@@ -8,9 +10,12 @@
 mod clic;
 mod timer;
 mod uart;
+mod spi;
 
 pub use clic::*;
 pub use timer::*;
 pub use uart::*;
+pub use spi::*;
 
+pub const DEBUG_ADDR: usize = 0x0;
 pub const LED_ADDR: usize = 0x3_0008;

--- a/examples/rt_ss_bsp/src/mmap/spi.rs
+++ b/examples/rt_ss_bsp/src/mmap/spi.rs
@@ -1,0 +1,1 @@
+pub const SPI_BASE_ADDR: usize = 0x6_0000;

--- a/examples/rt_ss_bsp/src/mmap/timer.rs
+++ b/examples/rt_ss_bsp/src/mmap/timer.rs
@@ -1,3 +1,4 @@
+//! Memory maps for mtimer
 pub const TIMER_BASE: usize = 0x30200;
 
 pub const MTIME_LOW_ADDR: usize = TIMER_BASE + 0;

--- a/examples/rust_minimal/link.x
+++ b/examples/rust_minimal/link.x
@@ -1,11 +1,16 @@
 _hart_stack_size = 0x400;
 
+/* Memory maps based on <src/ip/rt_pkg.sv> */
 MEMORY
 {
   /* Instruction memory : 0x4000 = 16 KiB */
   IMEM (rx ): ORIGIN = 0x1000, LENGTH = 0x4000
   /* Data memory        : 0x4000 = 16 KiB */
   DMEM (rwx): ORIGIN = 0x5000, LENGTH = 0x4000
+  /* ROM */
+  /* ROM (r): ORIGIN = 0x9000, LENGTH = 0x300 */
+  /* SRAM */
+  /* SRAM (rwx): ORIGIN = 0x20000, LENGTH = 0x10000 */
 }
 
 REGION_ALIAS("REGION_STACK", DMEM);


### PR DESCRIPTION
Non-breaking. Only change was to add missing addresses.

Fixes assumed board frequency for Rust SW.