### PR TITLE
chore: ignore Bender.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+# Bender
 .bender/
+Bender.local
+
 build/
 src/ip/safety_island
 src/tb/cheshire

--- a/Bender.local
+++ b/Bender.local
@@ -1,2 +1,0 @@
-overrides:
-  axi: { git: https://github.com/pulp-platform/axi.git , rev: "bfee21757bf090ec8e358456314b0b0fd3c90809" }


### PR DESCRIPTION
Bender's documentation says Bender.local should be ignored (https://github.com/pulp-platform/bender?tab=readme-ov-file#package-structure):

>  Bender.local: This optional file contains local configuration overrides. It should be ignored in version control, i.e. added to .gitignore. This file can be used to override dependencies with local variants. It is also used when the user asks for a local working copy of a dependency.