### PR TITLE
Refine CLIC HAL

### DIFF
--- a/examples/atalanta_bsp/Cargo.toml
+++ b/examples/atalanta_bsp/Cargo.toml
@@ -29,6 +29,3 @@ fpga = []
 rt = ["dep:riscv-rt", "panic"]
 panic = []
 ufmt = ["dep:ufmt"]
-clic-smclic = []
-# CLIC selective hardware vectoring extension
-clic-smclicshv = []

--- a/examples/atalanta_bsp/src/clic.rs
+++ b/examples/atalanta_bsp/src/clic.rs
@@ -7,7 +7,6 @@ pub mod intctl;
 pub mod intie;
 pub mod intip;
 pub mod inttrig;
-#[cfg(feature = "clic-smclic")]
 pub mod smclicconfig;
 
 pub use intattr::{Polarity, Trig};
@@ -23,7 +22,6 @@ pub type CLIC = Clic;
 impl Clic {
     const BASE: usize = crate::mmap::CLIC_BASE_ADDR;
 
-    #[cfg(feature = "clic-smclic")]
     const SMCLICCONFIG_OFFSET: usize = 0x0;
 
     const INTTRIG_OFFSET: usize = 0x40;
@@ -34,7 +32,6 @@ impl Clic {
 
     /// Returns the smclicconfig register of the CLIC.
     #[inline]
-    #[cfg(feature = "clic-smclic")]
     pub fn smclicconfig() -> smclicconfig::SMCLICCONFIG {
         // SAFETY: valid address
         unsafe { smclicconfig::SMCLICCONFIG::new(Self::BASE + Self::SMCLICCONFIG_OFFSET) }

--- a/examples/atalanta_bsp/src/clic/intattr.rs
+++ b/examples/atalanta_bsp/src/clic/intattr.rs
@@ -126,7 +126,6 @@ impl INTATTR {
 
     /// Check the selective hardware vectoring mode for this interrupt.
     #[inline]
-    #[cfg(feature = "clic-smclicshv")]
     pub fn shv(self) -> bool {
         // SAFETY: valid interrupt number
         let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
@@ -136,7 +135,6 @@ impl INTATTR {
 
     /// Set selective hardware vectoring mode for this interrupt.
     #[inline]
-    #[cfg(feature = "clic-smclicshv")]
     pub fn set_shv(self, shv: bool) {
         // SAFETY: valid interrupt number
         let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };

--- a/examples/atalanta_bsp/src/clic/intie.rs
+++ b/examples/atalanta_bsp/src/clic/intie.rs
@@ -70,4 +70,18 @@ impl INTIE {
         // > The enable bit is located in bit 0 of the byte.
         reg.clear_bit(0 + 8 * Self::INTIE_OFFSET);
     }
+
+    /// Sets the interrupt source as PCS or not
+    #[inline]
+    pub fn set_pcs(self, set_pcs: bool) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
+
+        // The PCS enable bit is located in bit 4 of the byte.
+        if set_pcs {
+            reg.set_bit(4 + 8 * Self::INTIE_OFFSET);
+        } else {
+            reg.clear_bit(4 + 8 * Self::INTIE_OFFSET);
+        }
+    }
 }

--- a/examples/hello_rt/Cargo.toml
+++ b/examples/hello_rt/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2021"
 [dependencies]
 bsp = { package = "atalanta_bsp", path = "../atalanta_bsp", features = [
     "rt",
-    "clic-smclic",
-    "clic-smclicshv",
 ] }
 fugit = "0.3.7"
 ufmt = "0.2.0"

--- a/examples/periodic_tasks/Cargo.toml
+++ b/examples/periodic_tasks/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2021"
 [dependencies]
 bsp = { package = "atalanta_bsp", path = "../atalanta_bsp", features = [
     "rt",
-    "clic-smclic",
-    "clic-smclicshv",
 ] }
 fugit = "0.3.7"
 ufmt = "0.2.0"


### PR DESCRIPTION
Make clic-smclicshv, clic-smclic non-features.

They are HW features, not SW features. They are active for the hardware all the time.