### PR TITLE
BSP (UART): read periph clk div instead of write

### DIFF
--- a/examples/atalanta_bsp/src/mmap/cfg.rs
+++ b/examples/atalanta_bsp/src/mmap/cfg.rs
@@ -1,0 +1,3 @@
+pub const CFG_BASE: usize = 0x3_0500;
+
+pub const PERIPH_CLK_DIV_OFS: usize = 0x0;

--- a/examples/atalanta_bsp/src/mmap/cfg.rs
+++ b/examples/atalanta_bsp/src/mmap/cfg.rs
@@ -1,3 +1,8 @@
 pub const CFG_BASE: usize = 0x3_0500;
 
+/// # Safety
+///
+/// Setting periph clk div will mess up timings for currently configured
+/// peripherals, so make sure to set this before configuring the peripherals, or
+/// make sure to reconfigure them.
 pub const PERIPH_CLK_DIV_OFS: usize = 0x0;

--- a/examples/atalanta_bsp/src/mmap/mod.rs
+++ b/examples/atalanta_bsp/src/mmap/mod.rs
@@ -8,12 +8,14 @@
 #![allow(clippy::identity_op)]
 
 pub(crate) mod apb_timer;
+mod cfg;
 mod clic;
 pub mod gpio;
 mod mtimer;
 mod spi;
 mod uart;
 
+pub use cfg::*;
 pub use clic::*;
 pub use mtimer::*;
 pub use spi::*;

--- a/examples/atalanta_bsp/src/uart.rs
+++ b/examples/atalanta_bsp/src/uart.rs
@@ -44,15 +44,13 @@ impl<const BASE_ADDR: usize> ApbUartHal<BASE_ADDR> {
     /// * `baud` - target BAUD (sa. UART protocol)
     #[inline]
     pub fn init(freq: u32, baud: u32) -> Self {
-        // This is the hardware default value; it could be made configurable
-        const PERIPH_CLK_DIV_VAL: u32 = 2;
-        let divisor: u32 = freq / PERIPH_CLK_DIV_VAL / (baud << 4);
-
         // Safety: all UART registers are 4-byte aligned which makes the below writes
         // always valid
         unsafe {
-            // set peripheral clock divider
-            write_u8(CFG_BASE + PERIPH_CLK_DIV_OFS, 0x2);
+            // Read current peripheral clock divider
+            let periph_clk_div = read_u8(CFG_BASE + PERIPH_CLK_DIV_OFS);
+            let divisor: u32 = freq / periph_clk_div as u32 / (baud << 4);
+
             // Disable all interrupts
             write_u8(BASE_ADDR + UART_IER_DLM_OFS, 0x00);
 

--- a/examples/atalanta_bsp/src/uart.rs
+++ b/examples/atalanta_bsp/src/uart.rs
@@ -43,7 +43,7 @@ impl<const BASE_ADDR: usize> ApbUartHal<BASE_ADDR> {
     ///   divisor
     /// * `baud` - target BAUD (sa. UART protocol)
     #[inline]
-    pub fn init(freq: u32, baud: u32 ) -> Self {
+    pub fn init(freq: u32, baud: u32) -> Self {
         // This is the hardware default value; it could be made configurable
         const PERIPH_CLK_DIV: u32 = 2;
         let divisor: u32 = freq / PERIPH_CLK_DIV / (baud << 4);

--- a/examples/atalanta_bsp/src/uart.rs
+++ b/examples/atalanta_bsp/src/uart.rs
@@ -45,14 +45,14 @@ impl<const BASE_ADDR: usize> ApbUartHal<BASE_ADDR> {
     #[inline]
     pub fn init(freq: u32, baud: u32) -> Self {
         // This is the hardware default value; it could be made configurable
-        const PERIPH_CLK_DIV: u32 = 2;
-        let divisor: u32 = freq / PERIPH_CLK_DIV / (baud << 4);
+        const PERIPH_CLK_DIV_VAL: u32 = 2;
+        let divisor: u32 = freq / PERIPH_CLK_DIV_VAL / (baud << 4);
 
         // Safety: all UART registers are 4-byte aligned which makes the below writes
         // always valid
         unsafe {
             // set peripheral clock divider
-            write_u8(0x0003_0500, 0x2);
+            write_u8(CFG_BASE + PERIPH_CLK_DIV_OFS, 0x2);
             // Disable all interrupts
             write_u8(BASE_ADDR + UART_IER_DLM_OFS, 0x00);
 


### PR DESCRIPTION
Read periph clk div instead of writing it. I believe it's not a desired side-effect of UART initializer that it reconfigures platform clocks.

Commit with actual changes: https://github.com/soc-hub-fi/Atalanta/pull/82/commits/000273efc1e18fb834e629f7240269d6071d7275