### PR TITLE
BSP: CSR access wrappers

### DIFF
--- a/examples/atalanta_bsp/src/lib.rs
+++ b/examples/atalanta_bsp/src/lib.rs
@@ -9,6 +9,7 @@ mod interrupt;
 pub mod led;
 pub mod mmap;
 pub mod mtimer;
+pub mod register;
 pub mod tb;
 pub mod timer_group;
 #[cfg(feature = "rt")]

--- a/examples/atalanta_bsp/src/register.rs
+++ b/examples/atalanta_bsp/src/register.rs
@@ -160,6 +160,8 @@ pub mod menvcfg;
 pub mod menvcfgh
 */
 
+// # CLIC registers
+
 pub mod mnxti {
     use riscv::{clear, read_csr_as, set, write_csr_as};
 
@@ -261,3 +263,5 @@ pub mod mclicbase {
     // Supported operations
     read_csr_as_usize!(0x350);
 }
+
+// # CLIC registers end

--- a/examples/atalanta_bsp/src/register.rs
+++ b/examples/atalanta_bsp/src/register.rs
@@ -1,0 +1,58 @@
+//! Unified access to base ISA CSRs + Ibex/Atalanta specific CSRs
+
+// Re-export base ISA registers
+pub use crate::riscv::register::*;
+
+pub mod mintthresh {
+    use riscv::{clear, read_csr_as, set, write_csr_as};
+
+    /// mintthresh register
+    ///
+    /// Holds an 8-bit field (th) for the threshold level of the associated
+    /// privilege mode. The th field is held in the least-significant 8 bits of
+    /// the CSR, and zero should be written to the upper bits.
+    ///
+    /// A typical usage of the interrupt-level threshold is for implementing
+    /// critical sections. The current handler can temporarily raise its
+    /// effective interrupt level to implement a critical section among a subset
+    /// of levels, while still allowing higher interrupt levels to preempt.
+    ///
+    /// The current hart’s effective interrupt level would then be:
+    /// effective_level = max(mintstatus.mil`, mintthresh.th)
+    ///
+    /// The max is used to prevent a hart from dropping below its original level
+    /// which would break assumptions in design, and also makes it simple for
+    /// software to remove threshold without knowing its own level by simply
+    /// setting mintthresh to the lowest supported mintthresh value.
+    ///
+    /// The interrupt-level threshold is only valid when running in associated
+    /// privilege mode and not in other modes. This is because interrupts for
+    /// lower privilege modes are always disabled, whereas interrupts for higher
+    /// privilege modes are always enabled.
+    #[derive(Clone, Copy)]
+    #[cfg_attr(feature = "ufmt", derive(crate::ufmt::derive::uDebug))]
+    #[cfg_attr(not(feature = "ufmt"), derive(Debug))]
+    pub struct Mintthresh {
+        bits: usize,
+    }
+
+    impl From<usize> for Mintthresh {
+        #[inline]
+        fn from(bits: usize) -> Self {
+            Self { bits }
+        }
+    }
+
+    impl Mintthresh {
+        /// Returns the contents of the register as raw bits
+        #[inline]
+        pub fn bits(&self) -> usize {
+            self.bits
+        }
+    }
+
+    read_csr_as!(Mintthresh, 0x347);
+    write_csr_as!(Mintthresh, 0x347);
+    set!(0x347);
+    clear!(0x347);
+}

--- a/examples/atalanta_bsp/src/register.rs
+++ b/examples/atalanta_bsp/src/register.rs
@@ -293,3 +293,20 @@ CSR_DSCRATCH1 = 12'h7b3, // optional
 */
 // # Debug registers end
 
+pub mod cpuctrlsts {
+    //! CPU Control and Status Register (Ibex Custom CSR)
+
+    use riscv::read_csr_as_usize;
+
+    // Supported operations
+    read_csr_as_usize!(0x7C0);
+}
+
+pub mod secureseed {
+    //! Security feature random seed (Ibex Custom CSR)
+
+    use riscv::read_csr_as_usize;
+
+    // Supported operations
+    read_csr_as_usize!(0x7C1);
+}

--- a/examples/atalanta_bsp/src/register.rs
+++ b/examples/atalanta_bsp/src/register.rs
@@ -3,6 +3,13 @@
 // Re-export base ISA registers
 pub use crate::riscv::register::*;
 
+pub mod mconfigptr {
+    use riscv::read_csr_as_usize;
+
+    // Supported operations
+    read_csr_as_usize!(0xF15);
+}
+
 pub mod mintthresh {
     use riscv::{clear, read_csr_as, set, write_csr_as};
 

--- a/examples/atalanta_bsp/src/register.rs
+++ b/examples/atalanta_bsp/src/register.rs
@@ -134,3 +134,9 @@ pub mod mtvt {
     set!(0x307);
     clear!(0x307);
 }
+
+// If U-mode is not supported, then registers menvcfg and menvcfgh do not exist.
+/*
+pub mod menvcfg;
+pub mod menvcfgh
+*/

--- a/examples/atalanta_bsp/src/register.rs
+++ b/examples/atalanta_bsp/src/register.rs
@@ -29,60 +29,6 @@ pub mod mconfigptr {
     read_csr_as_usize!(0xF15);
 }
 
-pub mod mintthresh {
-    use riscv::{clear, read_csr_as, set, write_csr_as};
-
-    /// mintthresh register
-    ///
-    /// Holds an 8-bit field (th) for the threshold level of the associated
-    /// privilege mode. The th field is held in the least-significant 8 bits of
-    /// the CSR, and zero should be written to the upper bits.
-    ///
-    /// A typical usage of the interrupt-level threshold is for implementing
-    /// critical sections. The current handler can temporarily raise its
-    /// effective interrupt level to implement a critical section among a subset
-    /// of levels, while still allowing higher interrupt levels to preempt.
-    ///
-    /// The current hart’s effective interrupt level would then be:
-    /// effective_level = max(mintstatus.mil`, mintthresh.th)
-    ///
-    /// The max is used to prevent a hart from dropping below its original level
-    /// which would break assumptions in design, and also makes it simple for
-    /// software to remove threshold without knowing its own level by simply
-    /// setting mintthresh to the lowest supported mintthresh value.
-    ///
-    /// The interrupt-level threshold is only valid when running in associated
-    /// privilege mode and not in other modes. This is because interrupts for
-    /// lower privilege modes are always disabled, whereas interrupts for higher
-    /// privilege modes are always enabled.
-    #[derive(Clone, Copy)]
-    #[cfg_attr(feature = "ufmt", derive(crate::ufmt::derive::uDebug))]
-    #[cfg_attr(not(feature = "ufmt"), derive(Debug))]
-    pub struct Mintthresh {
-        bits: usize,
-    }
-
-    impl From<usize> for Mintthresh {
-        #[inline]
-        fn from(bits: usize) -> Self {
-            Self { bits }
-        }
-    }
-
-    impl Mintthresh {
-        /// Returns the contents of the register as raw bits
-        #[inline]
-        pub fn bits(&self) -> usize {
-            self.bits
-        }
-    }
-
-    read_csr_as!(Mintthresh, 0x347);
-    write_csr_as!(Mintthresh, 0x347);
-    set!(0x347);
-    clear!(0x347);
-}
-
 pub mod mtvt {
     use riscv::{clear, read_csr_as, set, write_csr};
 
@@ -249,6 +195,60 @@ pub mod mintstatus {
     }
 
     read_csr_as!(Mintstatus, 0x346);
+}
+
+pub mod mintthresh {
+    use riscv::{clear, read_csr_as, set, write_csr_as};
+
+    /// mintthresh register
+    ///
+    /// Holds an 8-bit field (th) for the threshold level of the associated
+    /// privilege mode. The th field is held in the least-significant 8 bits of
+    /// the CSR, and zero should be written to the upper bits.
+    ///
+    /// A typical usage of the interrupt-level threshold is for implementing
+    /// critical sections. The current handler can temporarily raise its
+    /// effective interrupt level to implement a critical section among a subset
+    /// of levels, while still allowing higher interrupt levels to preempt.
+    ///
+    /// The current hart’s effective interrupt level would then be:
+    /// effective_level = max(mintstatus.mil`, mintthresh.th)
+    ///
+    /// The max is used to prevent a hart from dropping below its original level
+    /// which would break assumptions in design, and also makes it simple for
+    /// software to remove threshold without knowing its own level by simply
+    /// setting mintthresh to the lowest supported mintthresh value.
+    ///
+    /// The interrupt-level threshold is only valid when running in associated
+    /// privilege mode and not in other modes. This is because interrupts for
+    /// lower privilege modes are always disabled, whereas interrupts for higher
+    /// privilege modes are always enabled.
+    #[derive(Clone, Copy)]
+    #[cfg_attr(feature = "ufmt", derive(crate::ufmt::derive::uDebug))]
+    #[cfg_attr(not(feature = "ufmt"), derive(Debug))]
+    pub struct Mintthresh {
+        bits: usize,
+    }
+
+    impl From<usize> for Mintthresh {
+        #[inline]
+        fn from(bits: usize) -> Self {
+            Self { bits }
+        }
+    }
+
+    impl Mintthresh {
+        /// Returns the contents of the register as raw bits
+        #[inline]
+        pub fn bits(&self) -> usize {
+            self.bits
+        }
+    }
+
+    read_csr_as!(Mintthresh, 0x347);
+    write_csr_as!(Mintthresh, 0x347);
+    set!(0x347);
+    clear!(0x347);
 }
 
 // mscratchsw, mscratchswl are useful for multi-privilege only

--- a/examples/atalanta_bsp/src/register.rs
+++ b/examples/atalanta_bsp/src/register.rs
@@ -1,4 +1,6 @@
 //! Unified access to base ISA CSRs + Ibex/Atalanta specific CSRs
+//!
+//! * [Ibex register documentation](https://ibex-core.readthedocs.io/en/latest/03_reference/cs_registers.html)
 
 // Re-export base ISA registers
 pub use crate::riscv::register::*;

--- a/examples/atalanta_bsp/src/register.rs
+++ b/examples/atalanta_bsp/src/register.rs
@@ -265,3 +265,31 @@ pub mod mclicbase {
 }
 
 // # CLIC registers end
+
+// # Debug registers
+
+/*
+CSR_SCONTEXT  = 12'h5A8,
+
+// ePMP control
+CSR_MSECCFG   = 12'h747,
+CSR_MSECCFGH  = 12'h757,
+
+// Debug trigger
+CSR_TSELECT   = 12'h7A0,
+CSR_TDATA1    = 12'h7A1,
+CSR_TDATA2    = 12'h7A2,
+CSR_TDATA3    = 12'h7A3,
+CSR_MCONTEXT  = 12'h7A8,
+CSR_MSCONTEXT = 12'h7AA,
+
+// Debug/trace
+CSR_DCSR      = 12'h7b0,
+CSR_DPC       = 12'h7b1,
+
+// Debug
+CSR_DSCRATCH0 = 12'h7b2, // optional
+CSR_DSCRATCH1 = 12'h7b3, // optional
+*/
+// # Debug registers end
+

--- a/examples/atalanta_bsp/src/register.rs
+++ b/examples/atalanta_bsp/src/register.rs
@@ -248,3 +248,16 @@ pub mod mintstatus {
 
     read_csr_as!(Mintstatus, 0x346);
 }
+
+// mscratchsw, mscratchswl are useful for multi-privilege only
+/*
+pub mod mscratchsw;
+pub mod mscratchswl;
+*/
+
+pub mod mclicbase {
+    use riscv::read_csr_as_usize;
+
+    // Supported operations
+    read_csr_as_usize!(0x350);
+}

--- a/examples/atalanta_bsp/src/register.rs
+++ b/examples/atalanta_bsp/src/register.rs
@@ -140,3 +140,43 @@ pub mod mtvt {
 pub mod menvcfg;
 pub mod menvcfgh
 */
+
+pub mod mnxti {
+    use riscv::{clear, read_csr_as, set, write_csr_as};
+
+    /// mnxti register
+    ///
+    /// The mnxti CSR is used by software to improve the performance of handling
+    /// back-to-back software vectored interrupts. It does this by avoiding the
+    /// overhead of additional interrupt pipeline flushes and redundant context
+    /// save/restore for these back-to-back software vectored interrupts. The
+    /// mnxti CSR is intended to be used inside an interrupt handler after an
+    /// initial interrupt has been taken and mcause and mepc registers have been
+    /// updated with the interrupted context and the id of the interrupt.
+    #[derive(Clone, Copy)]
+    #[cfg_attr(feature = "ufmt", derive(crate::ufmt::derive::uDebug))]
+    #[cfg_attr(not(feature = "ufmt"), derive(Debug))]
+    pub struct Mnxti {
+        bits: usize,
+    }
+
+    impl From<usize> for Mnxti {
+        #[inline]
+        fn from(bits: usize) -> Self {
+            Self { bits }
+        }
+    }
+
+    impl Mnxti {
+        /// Returns the contents of the register as raw bits
+        #[inline]
+        pub fn bits(&self) -> usize {
+            self.bits
+        }
+    }
+
+    read_csr_as!(Mnxti, 0x345);
+    write_csr_as!(Mnxti, 0x345);
+    set!(0x345);
+    clear!(0x345);
+}

--- a/examples/atalanta_bsp/src/trap.rs
+++ b/examples/atalanta_bsp/src/trap.rs
@@ -1,5 +1,5 @@
-use crate::register::{mintthresh, mtvec};
-use core::arch::{asm, global_asm};
+use crate::register::{mintthresh, mtvec, mtvt};
+use core::arch::global_asm;
 
 #[cfg(feature = "rt")]
 #[export_name = "_setup_interrupts"]
@@ -13,8 +13,7 @@ fn setup_interrupt_vector() {
         // Set all the trap vectors for good measure
         let bits = _vector_table as usize;
         mtvec::write(bits, mtvec::TrapMode::Clic);
-        // 0x307 = mtvt
-        asm!("csrw 0x307, {0}", in(reg) bits | 0x3);
+        mtvt::write(bits, mtvt::TrapMode::Clic);
 
         mintthresh::write(0x00.into());
     }

--- a/examples/atalanta_bsp/src/trap.rs
+++ b/examples/atalanta_bsp/src/trap.rs
@@ -1,5 +1,5 @@
+use crate::register::{mintthresh, mtvec};
 use core::arch::{asm, global_asm};
-use riscv::register::mtvec;
 
 #[cfg(feature = "rt")]
 #[export_name = "_setup_interrupts"]
@@ -16,8 +16,7 @@ fn setup_interrupt_vector() {
         // 0x307 = mtvt
         asm!("csrw 0x307, {0}", in(reg) bits | 0x3);
 
-        // 0x347 = mintthresh
-        asm!("csrw 0x347, 0x00");
+        mintthresh::write(0x00.into());
     }
 }
 

--- a/examples/hello_rt/examples/clic_nested.rs
+++ b/examples/hello_rt/examples/clic_nested.rs
@@ -6,7 +6,7 @@
 #![no_main]
 #![no_std]
 
-use core::{arch::asm, ptr};
+use core::ptr;
 
 use bsp::{
     asm_delay,
@@ -38,9 +38,8 @@ fn main() -> ! {
 
     unsafe {
         // Raise interrupt threshold in RT-Ibex before enabling interrupts
-        // mintthresh = 0x347
         sprintln!("mintthresh <- 0xff");
-        asm!("csrw 0x347, {0}", in(reg) 0xff);
+        bsp::register::mintthresh::write(0xff.into());
 
         // Enable global interrupts
         riscv::interrupt::enable();
@@ -53,7 +52,7 @@ fn main() -> ! {
 
         // Lower interrupt threshold in RT-Ibex. Interrupts should fire.
         sprintln!("mintthresh <- 0x0");
-        asm!("csrw 0x347, {0}", in(reg) 0x0);
+        bsp::register::mintthresh::write(0x0.into());
     }
 
     asm_delay(1000);

--- a/examples/hello_rt/examples/csr.rs
+++ b/examples/hello_rt/examples/csr.rs
@@ -1,0 +1,53 @@
+//! Prints all CSRs added by Atalanta and the most interesting base ISA
+//! registers.
+#![no_main]
+#![no_std]
+
+use bsp::{
+    // Import all registers from `bsp::register::*`
+    register::*,
+    riscv::asm::wfi,
+    rt::entry,
+    uart::*,
+    CPU_FREQ,
+};
+use hello_rt::{print_example_name, UART_BAUD};
+
+macro_rules! print_struct_csr {
+    ($csr:path) => {
+        sprintln!("{}: {:#x}", stringify!($csr), $csr::read().bits());
+    };
+}
+
+macro_rules! print_csr {
+    ($csr:path) => {
+        sprintln!("{}: {:#x}", stringify!($csr), $csr::read());
+    };
+}
+
+#[entry]
+fn main() -> ! {
+    let _serial = ApbUart::init(CPU_FREQ, UART_BAUD);
+
+    print_example_name!();
+
+    // Print all registers added by Atalanta BSP and the most interesting base ISA
+    // registers.
+
+    print_csr!(mconfigptr);
+    print_struct_csr!(mtvec);
+    print_struct_csr!(mtvt);
+    print_struct_csr!(mintstatus);
+    print_struct_csr!(mintthresh);
+    print_csr!(mclicbase);
+    assert_eq!(mclicbase::read(), bsp::mmap::CLIC_BASE_ADDR);
+    print_csr!(cpuctrlsts);
+    print_csr!(secureseed);
+
+    #[cfg(feature = "rtl-tb")]
+    bsp::tb::rtl_tb_signal_ok();
+
+    loop {
+        wfi();
+    }
+}

--- a/examples/hello_rt/examples/nested_interrupt_macros.rs
+++ b/examples/hello_rt/examples/nested_interrupt_macros.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![allow(non_snake_case)]
 
-use core::{arch::asm, ptr};
+use core::ptr;
 
 use bsp::{
     clic::{
@@ -34,9 +34,8 @@ fn main() -> ! {
 
     unsafe {
         // Raise interrupt threshold in RT-Ibex before enabling interrupts
-        // mintthresh = 0x347
         sprintln!("mintthresh <- 0xff");
-        asm!("csrw 0x347, {0}", in(reg) 0xff);
+        bsp::register::mintthresh::write(0xff.into());
 
         // Enable global interrupts
         riscv::interrupt::enable();
@@ -47,7 +46,7 @@ fn main() -> ! {
 
         // Lower interrupt threshold in RT-Ibex. Interrupts should fire.
         sprintln!("mintthresh <- 0x0");
-        asm!("csrw 0x347, {0}", in(reg) 0x0);
+        bsp::register::mintthresh::write(0x0.into());
     }
 
     while unsafe { ptr::read_volatile(ptr::addr_of_mut!(LOCK)) } != 2u8 {}

--- a/examples/hello_rt/examples/nested_pcs_interrupt_macros.rs
+++ b/examples/hello_rt/examples/nested_pcs_interrupt_macros.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![allow(non_snake_case)]
 
-use core::{arch::asm, ptr};
+use core::ptr;
 
 use bsp::{
     clic::{
@@ -61,9 +61,8 @@ fn main() -> ! {
 
         unsafe {
             // Raise interrupt threshold in RT-Ibex before enabling interrupts
-            // mintthresh = 0x347
             sprintln!("mintthresh <- 0xff");
-            asm!("csrw 0x347, {0}", in(reg) 0xff);
+            bsp::register::mintthresh::write(0xff.into());
 
             // Enable global interrupts
             riscv::interrupt::enable();
@@ -74,7 +73,7 @@ fn main() -> ! {
 
             // Lower interrupt threshold in RT-Ibex. Interrupts should fire.
             sprintln!("mintthresh <- 0x0");
-            asm!("csrw 0x347, {0}", in(reg) 0x0);
+            bsp::register::mintthresh::write(0x0.into());
         }
 
         while unsafe { ptr::read_volatile(ptr::addr_of_mut!(LOCK)) } != 2u8 {}


### PR DESCRIPTION
For all special Ibex & Atalanta registers. Also re-exports riscv::registers under bsp::registers.